### PR TITLE
WKS-928 - Expose commands

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/workers-cli/commands"
+)
+
+func GetApp() components.App {
+	app := components.App{}
+	app.Name = "worker"
+	app.Description = "Tools for managing workers"
+	app.Version = "v1.0.0"
+	app.Commands = getCommands()
+	return app
+}
+
+func getCommands() []components.Command {
+	return []components.Command{
+		commands.GetInitCommand(),
+		commands.GetDryRunCommand(),
+		commands.GetDeployCommand(),
+		commands.GetExecuteCommand(),
+		commands.GetRemoveCommand(),
+		commands.GetListCommand(),
+		commands.GetAddSecretCommand(),
+		commands.GetListEventsCommand(),
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,33 +2,9 @@ package main
 
 import (
 	"github.com/jfrog/jfrog-cli-core/v2/plugins"
-	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
-
-	"github.com/jfrog/workers-cli/commands"
+	"github.com/jfrog/workers-cli/cli"
 )
 
 func main() {
-	plugins.PluginMain(getApp())
-}
-
-func getApp() components.App {
-	app := components.App{}
-	app.Name = "worker"
-	app.Description = "Tools for managing workers"
-	app.Version = "v1.0.0"
-	app.Commands = getCommands()
-	return app
-}
-
-func getCommands() []components.Command {
-	return []components.Command{
-		commands.GetInitCommand(),
-		commands.GetDryRunCommand(),
-		commands.GetDeployCommand(),
-		commands.GetExecuteCommand(),
-		commands.GetRemoveCommand(),
-		commands.GetListCommand(),
-		commands.GetAddSecretCommand(),
-		commands.GetListEventsCommand(),
-	}
+	plugins.PluginMain(cli.GetApp())
 }


### PR DESCRIPTION
- [x] The pull request is targeting the `main` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/workers-cli/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/workers-cli/actions/workflows/unit-tests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----