### PR TITLE
Do not send empty filter criteria into deploy payload

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,9 +37,8 @@ linters-settings:
         # https://staticcheck.io/docs/options#checks
         checks: [ "all","-SA1019","-SA1029" ]
     gosec:
-        excludes: ["G204", "G301", "G302", "G304", "G306", "G601", "G101", "G407"]
+        excludes: ["G204", "G301", "G302", "G304", "G306", "G601", "G101"]
         exclude-generated: true
-        exclude-test-files: true
         config:
             global:
                 nosec: true

--- a/commands/common/manifest_test.go
+++ b/commands/common/manifest_test.go
@@ -29,7 +29,7 @@ var manifestSample = &model.Manifest{
 		"hidden1": "hidden1.value",
 		"hidden2": "hidden2.value",
 	},
-	FilterCriteria: model.FilterCriteria{
+	FilterCriteria: &model.FilterCriteria{
 		ArtifactFilterCriteria: &model.ArtifactFilterCriteria{
 			RepoKeys: []string{
 				"my-repo-local",

--- a/commands/deploy_cmd.go
+++ b/commands/deploy_cmd.go
@@ -61,7 +61,7 @@ func GetDeployCommand() components.Command {
 				return err
 			}
 
-			if err = common.ValidateFilterCriteria(&manifest.FilterCriteria, actionMeta); err != nil {
+			if err = common.ValidateFilterCriteria(manifest.FilterCriteria, actionMeta); err != nil {
 				return err
 			}
 
@@ -149,7 +149,7 @@ func prepareDeployRequest(ctx *components.Context, manifest *model.Manifest, act
 	}
 
 	if actionMeta.MandatoryFilter {
-		payload.FilterCriteria = &manifest.FilterCriteria
+		payload.FilterCriteria = manifest.FilterCriteria
 	}
 
 	return payload, nil

--- a/commands/deploy_cmd_test.go
+++ b/commands/deploy_cmd_test.go
@@ -115,9 +115,11 @@ func TestDeployCommand(t *testing.T) {
 			workerName:     "wk-3",
 			serverBehavior: common.NewServerStub(t).WithGetOneEndpoint(),
 			patchManifest: func(mf *model.Manifest) {
-				mf.FilterCriteria.Schedule = &model.ScheduleFilterCriteria{
-					Cron:     "1h",
-					Timezone: "Asia/New_York",
+				mf.FilterCriteria = &model.FilterCriteria{
+					Schedule: &model.ScheduleFilterCriteria{
+						Cron:     "1h",
+						Timezone: "Asia/New_York",
+					},
 				}
 			},
 			wantErr: errors.New("manifest validation failed: invalid cron expression"),

--- a/commands/edit_schedule_cmd.go
+++ b/commands/edit_schedule_cmd.go
@@ -59,7 +59,9 @@ func (c *editScheduleCommand) run() error {
 		return fmt.Errorf("invalid schedule provided: %w", err)
 	}
 
-	manifest.FilterCriteria.Schedule = newCriteria
+	manifest.FilterCriteria = &model.FilterCriteria{
+		Schedule: newCriteria,
+	}
 
 	if err = common.SaveManifest(manifest); err != nil {
 		return fmt.Errorf("failed to save manifest: %w", err)

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -20,14 +20,14 @@ type FilterCriteria struct {
 type Secrets map[string]string
 
 type Manifest struct {
-	Name           string         `json:"name"`
-	Description    string         `json:"description"`
-	SourceCodePath string         `json:"sourceCodePath"`
-	Action         string         `json:"action"`
-	Enabled        bool           `json:"enabled"`
-	Debug          bool           `json:"debug"`
-	ProjectKey     string         `json:"projectKey"`
-	Secrets        Secrets        `json:"secrets"`
-	FilterCriteria FilterCriteria `json:"filterCriteria,omitempty"`
-	Application    string         `json:"application,omitempty"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description"`
+	SourceCodePath string          `json:"sourceCodePath"`
+	Action         string          `json:"action"`
+	Enabled        bool            `json:"enabled"`
+	Debug          bool            `json:"debug"`
+	ProjectKey     string          `json:"projectKey"`
+	Secrets        Secrets         `json:"secrets"`
+	FilterCriteria *FilterCriteria `json:"filterCriteria,omitempty"`
+	Application    string          `json:"application,omitempty"`
 }

--- a/model/worker.go
+++ b/model/worker.go
@@ -6,13 +6,13 @@ type Secret struct {
 	MarkedForRemoval bool   `json:"markedForRemoval"`
 }
 type WorkerDetails struct {
-	Key            string         `json:"key"`
-	Description    string         `json:"description"`
-	Debug          bool           `json:"debug"`
-	Enabled        bool           `json:"enabled"`
-	SourceCode     string         `json:"sourceCode"`
-	Action         string         `json:"action"`
-	FilterCriteria FilterCriteria `json:"filterCriteria,omitempty"`
-	Secrets        []*Secret      `json:"secrets"`
-	ProjectKey     string         `json:"projectKey"`
+	Key            string          `json:"key"`
+	Description    string          `json:"description"`
+	Debug          bool            `json:"debug"`
+	Enabled        bool            `json:"enabled"`
+	SourceCode     string          `json:"sourceCode"`
+	Action         string          `json:"action"`
+	FilterCriteria *FilterCriteria `json:"filterCriteria,omitempty"`
+	Secrets        []*Secret       `json:"secrets"`
+	ProjectKey     string          `json:"projectKey"`
 }

--- a/test/commands/list_cmd_test.go
+++ b/test/commands/list_cmd_test.go
@@ -53,7 +53,7 @@ func TestListCommand(t *testing.T) {
 			Enabled:     true,
 			SourceCode:  `export default async function() { return { "status": "OK" } }`,
 			Action:      "BEFORE_DOWNLOAD",
-			FilterCriteria: model.FilterCriteria{
+			FilterCriteria: &model.FilterCriteria{
 				ArtifactFilterCriteria: &model.ArtifactFilterCriteria{
 					RepoKeys: []string{"example-repo-local"},
 				},


### PR DESCRIPTION
- [x] The pull request is targeting the `main` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/tests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All integration tests have passed locally as they cannot be automated yet.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----