### PR TITLE
Fix panic during itest due to out-of-range

### DIFF
--- a/test/commands/list_cmd_test.go
+++ b/test/commands/list_cmd_test.go
@@ -168,7 +168,7 @@ func assertWorkerListJSON(workers ...*model.WorkerDetails) func(t require.Testin
 
 		require.NoError(t, json.Unmarshal(content, &gotWorkers))
 
-		assert.Equalf(t, len(workers), len(gotWorkers.Workers), "Length mismatch")
+		require.Equalf(t, len(workers), len(gotWorkers.Workers), "Length mismatch")
 
 		common.SortWorkers(workers)
 		common.SortWorkers(gotWorkers.Workers)


### PR DESCRIPTION
- [x] The pull request is targeting the `main` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/tests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All integration tests have passed locally as they cannot be automated yet.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----