### PR TITLE
WKS-2374 - Increase timeout and clear body request before retries. Us…

### DIFF
--- a/test/commands/deploy_cmd_test.go
+++ b/test/commands/deploy_cmd_test.go
@@ -93,7 +93,10 @@ func deployTestSpec(tc deployTestCase) infra.TestDefinition {
 		Only: tc.only,
 		Skip: tc.skip,
 		Test: func(it *infra.Test) {
+			suffix := infra.UniqueID()
+
 			for _, initialWorker := range tc.initWorkers {
+				initialWorker.Key = initialWorker.Key + "-" + suffix
 				it.CreateWorker(initialWorker)
 				it.Cleanup(func() {
 					it.DeleteWorker(initialWorker.Key)
@@ -102,7 +105,7 @@ func deployTestSpec(tc deployTestCase) infra.TestDefinition {
 
 			_, workerName := it.PrepareWorkerTestDir()
 			if tc.workerKey != "" {
-				workerName = tc.workerKey
+				workerName = tc.workerKey + "-" + suffix
 			}
 
 			workerAction := tc.workerAction
@@ -147,7 +150,7 @@ func deployTestSpec(tc deployTestCase) infra.TestDefinition {
 }
 
 func assertWorkerDeployed(it *infra.Test, mf *model.Manifest) {
-	ctx, cancelCtx := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 15*time.Second)
 	it.Cleanup(cancelCtx)
 
 	deployed := model.WorkerDetails{}

--- a/test/commands/execute_cmd_test.go
+++ b/test/commands/execute_cmd_test.go
@@ -109,10 +109,18 @@ func executeSpec(tc executeTestCase) infra.TestDefinition {
 		Skip:          tc.skip,
 		CaptureOutput: true,
 		Test: func(it *infra.Test) {
+			suffix := infra.UniqueID()
+
 			workerDir, workerName := it.PrepareWorkerTestDir()
 
 			if tc.workerKey != "" {
-				workerName = tc.workerKey
+				uniqueKey := tc.workerKey + "-" + suffix
+				for i, arg := range tc.commandArgs {
+					if arg == tc.workerKey {
+						tc.commandArgs[i] = uniqueKey
+					}
+				}
+				workerName = uniqueKey
 			}
 
 			action := "GENERIC_EVENT"

--- a/test/commands/list_cmd_test.go
+++ b/test/commands/list_cmd_test.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/jfrog/jfrog-cli-platform-services/commands/common"
 
@@ -32,23 +31,25 @@ type listTestCase struct {
 }
 
 func TestListCommand(t *testing.T) {
+	id := infra.UniqueID()
+
 	initialWorkers := []*model.WorkerDetails{
 		{
-			Key:         fmt.Sprintf("w%v", time.Now().Unix()),
+			Key:         "w0-" + id,
 			Description: "My worker 0",
 			Enabled:     true,
 			SourceCode:  `export default async function() { return { "status": "OK" } }`,
 			Action:      "GENERIC_EVENT",
 		},
 		{
-			Key:         fmt.Sprintf("w%v", time.Now().Unix()+1),
+			Key:         "w1-" + id,
 			Description: "My worker 1",
 			Enabled:     true,
 			SourceCode:  `export default async function() { return { "status": "OK" } }`,
 			Action:      "GENERIC_EVENT",
 		},
 		{
-			Key:         fmt.Sprintf("w%v", time.Now().Unix()+2),
+			Key:         "w2-" + id,
 			Description: "My worker 2",
 			Enabled:     true,
 			SourceCode:  `export default async function() { return { "status": "OK" } }`,
@@ -62,7 +63,7 @@ func TestListCommand(t *testing.T) {
 	}
 
 	workerWithProject := &model.WorkerDetails{
-		Key:         fmt.Sprintf("w%v", time.Now().Unix()+3),
+		Key:         "w3-" + id,
 		Description: "My worker 3",
 		Enabled:     true,
 		Debug:       true,

--- a/test/commands/remove_cmd_test.go
+++ b/test/commands/remove_cmd_test.go
@@ -51,9 +51,17 @@ func removeTestSpec(tc removeTestCase) infra.TestDefinition {
 		Only: tc.only,
 		Skip: tc.skip,
 		Test: func(it *infra.Test) {
+			suffix := infra.UniqueID()
+
 			_, workerName := it.PrepareWorkerTestDir()
 			if tc.workerKey != "" {
-				workerName = tc.workerKey
+				uniqueKey := tc.workerKey + "-" + suffix
+				for i, arg := range tc.commandArgs {
+					if arg == tc.workerKey {
+						tc.commandArgs[i] = uniqueKey
+					}
+				}
+				workerName = uniqueKey
 			}
 
 			err := it.RunCommand(infra.AppName, "init", "GENERIC_EVENT", workerName)
@@ -86,7 +94,7 @@ func removeTestSpec(tc removeTestCase) infra.TestDefinition {
 }
 
 func assertWorkerRemoved(it *infra.Test, mf *model.Manifest) {
-	ctx, cancelCtx := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 15*time.Second)
 	it.Cleanup(cancelCtx)
 
 	it.NewHttpRequestWithContext(ctx).

--- a/test/infra/http_utils.go
+++ b/test/infra/http_utils.go
@@ -3,6 +3,7 @@
 package infra
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -138,6 +139,21 @@ func (h *HttpExecutor) DoAndCaptureError() (*HttpResponse, error) {
 }
 
 func (h *HttpExecutor) doWithRetries() (*HttpResponse, error) {
+	var bodyBytes []byte
+	if h.request.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(h.request.Body)
+		_ = h.request.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		h.request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		h.request.ContentLength = int64(len(bodyBytes))
+		h.request.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
+	}
+
 	start := time.Now()
 
 	resp, err := http.DefaultClient.Do(h.request)
@@ -150,6 +166,9 @@ func (h *HttpExecutor) doWithRetries() (*HttpResponse, error) {
 
 	for slices.Index(h.retryOnStatuses, resp.StatusCode) > -1 && elapsed < h.retryTimeout {
 		time.Sleep(backoff)
+		if bodyBytes != nil {
+			h.request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
 		resp, err = http.DefaultClient.Do(h.request)
 		if err != nil {
 			return nil, err

--- a/test/infra/itest_runner.go
+++ b/test/infra/itest_runner.go
@@ -49,9 +49,9 @@ type Test struct {
 }
 
 const (
-	requestTimeout      = 5 * time.Second
+	requestTimeout      = 15 * time.Second
 	defaultRetryBackoff = 250 * time.Millisecond
-	defaultRetryTimeout = 2 * time.Second
+	defaultRetryTimeout = 10 * time.Second
 )
 
 var defaultRetryCommandOnErrors = []string{
@@ -357,6 +357,10 @@ func (it *Test) Run(name string, f func(t *Test)) bool {
 	return it.t.Run(name, func(t *testing.T) {
 		f(&Test{t: t, ServerId: it.ServerId, AccessToken: it.AccessToken, dataDir: it.dataDir, stdout: it.stdout, stdin: it.stdin, input: it.input})
 	})
+}
+
+func UniqueID() string {
+	return uuid.NewString()[:8]
 }
 
 func (it *Test) NewHttpRequest() *HttpRequest {

--- a/test/infra/secrets_utils.go
+++ b/test/infra/secrets_utils.go
@@ -4,7 +4,6 @@ package infra
 
 import (
 	"context"
-	"time"
 
 	"github.com/jfrog/jfrog-cli-platform-services/commands/common"
 
@@ -17,7 +16,7 @@ func AddSecretPasswordToEnv(t common.Test) {
 }
 
 func AssertSecretValueFromServer(it *Test, workerKey string, secretKey string, wantValue string) {
-	ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancelCtx := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancelCtx()
 
 	check := struct {


### PR DESCRIPTION
…e of unique worker keys

- [ ] The pull request is targeting the `main` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/tests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All integration tests have passed locally as they cannot be automated yet.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----