### PR TITLE
WKS-2076 - Add base64 encoding support for source code

### DIFF
--- a/commands/common/options.go
+++ b/commands/common/options.go
@@ -13,4 +13,5 @@ type OptionsMetadata struct {
 	IsTutorialAvailable                    bool           `json:"isTutorialAvailable"`
 	IsFeedbackEnabled                      bool           `json:"isFeedbackEnabled"`
 	IsHistoryEnabled                       bool           `json:"isHistoryEnabled"`
+	ShouldEncodeSourceCodeInBase64         *bool          `json:"shouldEncodeSourceCodeInBase64"`
 }

--- a/commands/common/test_worker_server.go
+++ b/commands/common/test_worker_server.go
@@ -109,14 +109,15 @@ func NewServerStub(t *testing.T) *ServerStub {
 }
 
 type ServerStub struct {
-	test             *testing.T
-	waitFor          time.Duration
-	token            string
-	projectKey       *queryParamStub
-	workers          map[string]*model.WorkerDetails
-	executionHistory map[string]ExecutionHistoryStub
-	endpoints        []mockhttp.ServerEndpoint
-	queryParams      map[string]queryParamStub
+	test               *testing.T
+	waitFor            time.Duration
+	token              string
+	projectKey         *queryParamStub
+	workers            map[string]*model.WorkerDetails
+	executionHistory   map[string]ExecutionHistoryStub
+	endpoints          []mockhttp.ServerEndpoint
+	queryParams        map[string]queryParamStub
+	optionsForceBase64 bool
 }
 
 func (s *ServerStub) WithT(t *testing.T) *ServerStub {
@@ -291,6 +292,11 @@ func (s *ServerStub) WithOptionsEndpoint() *ServerStub {
 			HandleWith(s.handleGetOptions),
 	)
 	return s
+}
+
+func (s *ServerStub) WithBase64OptionsEndpoint() *ServerStub {
+	s.optionsForceBase64 = true
+	return s.WithOptionsEndpoint()
 }
 
 func (s *ServerStub) handleGetAll(res http.ResponseWriter, req *http.Request) {
@@ -492,6 +498,10 @@ func (s *ServerStub) handleGetOptions(res http.ResponseWriter, req *http.Request
 	res.WriteHeader(http.StatusOK)
 
 	options := LoadSampleOptions(s.test)
+	if s.optionsForceBase64 {
+		forcedBase64 := true
+		options.ShouldEncodeSourceCodeInBase64 = &forcedBase64
+	}
 	_, err := res.Write([]byte(MustJsonMarshal(s.test, options)))
 	require.NoError(s.test, err)
 }

--- a/commands/common/testdata/options.json
+++ b/commands/common/testdata/options.json
@@ -8,5 +8,6 @@
   "minArtifactoryVersionForProjectSupport": "7.95.0",
   "isTutorialAvailable": false,
   "isFeedbackEnabled": false,
-  "isHistoryEnabled": true
+  "isHistoryEnabled": true,
+  "shouldEncodeSourceCodeInBase64": false
 }

--- a/commands/deploy_cmd.go
+++ b/commands/deploy_cmd.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -39,6 +40,7 @@ func GetDeployCommand() components.Command {
 			model.GetChangesVersionFlag(),
 			model.GetChangesDescriptionFlag(),
 			model.GetChangesCommitShaFlag(),
+			model.GetBase64Flag(),
 		},
 		Action: func(c *components.Context) error {
 			server, err := model.GetServerDetails(c)
@@ -80,27 +82,38 @@ func GetDeployCommand() components.Command {
 				Description: c.GetStringFlagValue(model.FlagChangesDescription),
 				CommitSha:   c.GetStringFlagValue(model.FlagChangesCommitSha),
 			}
+
+			options, err := common.FetchOptions(c, server.GetUrl(), server.GetAccessToken())
+			if err != nil {
+				return err
+			}
+
 			if !version.IsEmpty() {
-				options, err := common.FetchOptions(c, server.GetUrl(), server.GetAccessToken())
-				if err != nil {
-					return err
-				}
 				if err = common.ValidateVersion(version, options); err != nil {
 					return err
 				}
 			}
-			return runDeployCommand(c, manifest, actionMeta, version, server.GetUrl(), server.GetAccessToken())
+
+			var encodeSourceCodeInBase64 bool
+			if options.ShouldEncodeSourceCodeInBase64 == nil {
+				if c.IsFlagSet(model.FlagBase64) {
+					log.Warn("The --base64 flag is not supported by this server. It will be ignored.")
+				}
+			} else {
+				encodeSourceCodeInBase64 = *options.ShouldEncodeSourceCodeInBase64 || c.GetBoolFlagValue(model.FlagBase64)
+			}
+			return runDeployCommand(c, manifest, actionMeta, version, server.GetUrl(), server.GetAccessToken(), encodeSourceCodeInBase64)
 		},
 	}
 }
 
-func runDeployCommand(ctx *components.Context, manifest *model.Manifest, actionMeta *model.ActionMetadata, version *model.Version, serverURL string, token string) error {
+func runDeployCommand(ctx *components.Context, manifest *model.Manifest, actionMeta *model.ActionMetadata, version *model.Version, serverURL string, token string, encodeSourceCodeInBase64 bool) error {
 	existingWorker, err := common.FetchWorkerDetails(ctx, serverURL, token, manifest.Name, manifest.ProjectKey)
 	if err != nil {
 		return err
 	}
 
-	body, err := prepareDeployRequest(ctx, manifest, actionMeta, version, existingWorker)
+	body, err := prepareDeployRequest(ctx, manifest, actionMeta, version, existingWorker, encodeSourceCodeInBase64)
 	if err != nil {
 		return err
 	}
@@ -144,12 +157,16 @@ func runDeployCommand(ctx *components.Context, manifest *model.Manifest, actionM
 	return err
 }
 
-func prepareDeployRequest(ctx *components.Context, manifest *model.Manifest, actionMeta *model.ActionMetadata, version *model.Version, existingWorker *model.WorkerDetails) (*deployRequest, error) {
+func prepareDeployRequest(ctx *components.Context, manifest *model.Manifest, actionMeta *model.ActionMetadata, version *model.Version, existingWorker *model.WorkerDetails, encodeSourceCodeInBase64 bool) (*deployRequest, error) {
 	sourceCode, err := common.ReadSourceCode(manifest)
 	if err != nil {
 		return nil, err
 	}
 	sourceCode = common.CleanImports(sourceCode)
+
+	if encodeSourceCodeInBase64 {
+		sourceCode = "base64:" + base64.StdEncoding.EncodeToString([]byte(sourceCode))
+	}
 
 	var secrets []*model.Secret
 

--- a/commands/deploy_cmd_test.go
+++ b/commands/deploy_cmd_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,6 +38,7 @@ func TestDeployCommand(t *testing.T) {
 			workerName:   "wk-0",
 			serverBehavior: common.NewServerStub(t).
 				WithGetOneEndpoint().
+				WithOptionsEndpoint().
 				WithCreateEndpoint(
 					expectDeployRequest(
 						actionsMeta,
@@ -60,6 +62,7 @@ func TestDeployCommand(t *testing.T) {
 			workerName:   "wk-1",
 			serverBehavior: common.NewServerStub(t).
 				WithGetOneEndpoint().
+				WithOptionsEndpoint().
 				WithUpdateEndpoint(
 					expectDeployRequest(actionsMeta, "wk-1", "GENERIC_EVENT", ""),
 				).
@@ -73,6 +76,7 @@ func TestDeployCommand(t *testing.T) {
 			workerName:   "wk-2",
 			serverBehavior: common.NewServerStub(t).
 				WithGetOneEndpoint().
+				WithOptionsEndpoint().
 				WithUpdateEndpoint(
 					expectDeployRequest(
 						actionsMeta,
@@ -102,6 +106,7 @@ func TestDeployCommand(t *testing.T) {
 			workerName:   "wk-1",
 			serverBehavior: common.NewServerStub(t).
 				WithGetOneEndpoint().
+				WithOptionsEndpoint().
 				WithCreateEndpoint(
 					expectDeployRequest(actionsMeta, "wk-1", "GENERIC_EVENT", "proj-1"),
 				),
@@ -113,7 +118,7 @@ func TestDeployCommand(t *testing.T) {
 			name:           "should validate schedule",
 			workerAction:   "SCHEDULED_EVENT",
 			workerName:     "wk-3",
-			serverBehavior: common.NewServerStub(t).WithGetOneEndpoint(),
+			serverBehavior: common.NewServerStub(t).WithGetOneEndpoint().WithOptionsEndpoint(),
 			patchManifest: func(mf *model.Manifest) {
 				mf.FilterCriteria = &model.FilterCriteria{
 					Schedule: &model.ScheduleFilterCriteria{
@@ -129,6 +134,7 @@ func TestDeployCommand(t *testing.T) {
 			commandArgs: []string{"--" + model.FlagTimeout, "500"},
 			serverBehavior: common.NewServerStub(t).
 				WithDelay(1 * time.Second).
+				WithOptionsEndpoint().
 				WithCreateEndpoint(nil),
 			wantErr: errors.New("request timed out after 500ms"),
 		},
@@ -154,6 +160,58 @@ func TestDeployCommand(t *testing.T) {
 					),
 				),
 			commandArgs: []string{"--" + model.FlagChangesVersion, "version number", "--" + model.FlagChangesDescription, "version description", "--" + model.FlagChangesCommitSha, "version commitsha"},
+		},
+		{
+			name:         "create with base64 encoding",
+			workerAction: "BEFORE_UPLOAD",
+			workerName:   "wk-0",
+			commandArgs:  []string{"--" + model.FlagBase64},
+			serverBehavior: common.NewServerStub(t).
+				WithGetOneEndpoint().
+				WithOptionsEndpoint().
+				WithCreateEndpoint(
+					expectDeployRequestBase64(actionsMeta, "wk-0", "BEFORE_UPLOAD", ""),
+				),
+		},
+		{
+			name:         "update with base64 encoding",
+			workerAction: "GENERIC_EVENT",
+			workerName:   "wk-1",
+			commandArgs:  []string{"--" + model.FlagBase64},
+			serverBehavior: common.NewServerStub(t).
+				WithGetOneEndpoint().
+				WithOptionsEndpoint().
+				WithUpdateEndpoint(
+					expectDeployRequestBase64(actionsMeta, "wk-1", "GENERIC_EVENT", ""),
+				).
+				WithWorkers(&model.WorkerDetails{
+					Key: "wk-1",
+				}),
+		},
+		{
+			name:         "create with base64 from options",
+			workerAction: "BEFORE_UPLOAD",
+			workerName:   "wk-0",
+			serverBehavior: common.NewServerStub(t).
+				WithGetOneEndpoint().
+				WithBase64OptionsEndpoint().
+				WithCreateEndpoint(
+					expectDeployRequestBase64(actionsMeta, "wk-0", "BEFORE_UPLOAD", ""),
+				),
+		},
+		{
+			name:         "update with base64 from options",
+			workerAction: "GENERIC_EVENT",
+			workerName:   "wk-1",
+			serverBehavior: common.NewServerStub(t).
+				WithGetOneEndpoint().
+				WithBase64OptionsEndpoint().
+				WithUpdateEndpoint(
+					expectDeployRequestBase64(actionsMeta, "wk-1", "GENERIC_EVENT", ""),
+				).
+				WithWorkers(&model.WorkerDetails{
+					Key: "wk-1",
+				}),
 		},
 		{
 			name: "fails when version invalid",
@@ -232,6 +290,17 @@ func assertDeployRequestEquals(t require.TestingT, want, got *deployRequest) {
 func expectDeployRequest(actionsMeta common.ActionsMetadata, workerName, actionName, projectKey string, secrets ...*model.Secret) common.BodyValidator {
 	return func(t require.TestingT, body []byte) {
 		want := getExpectedDeployRequestForAction(t, actionsMeta, workerName, actionName, projectKey, secrets...)
+		got := &deployRequest{}
+		err := json.Unmarshal(body, got)
+		require.NoError(t, err)
+		assertDeployRequestEquals(t, want, got)
+	}
+}
+
+func expectDeployRequestBase64(actionsMeta common.ActionsMetadata, workerName, actionName, projectKey string, secrets ...*model.Secret) common.BodyValidator {
+	return func(t require.TestingT, body []byte) {
+		want := getExpectedDeployRequestForAction(t, actionsMeta, workerName, actionName, projectKey, secrets...)
+		want.SourceCode = "base64:" + base64.StdEncoding.EncodeToString([]byte(want.SourceCode))
 		got := &deployRequest{}
 		err := json.Unmarshal(body, got)
 		require.NoError(t, err)

--- a/model/flags.go
+++ b/model/flags.go
@@ -25,6 +25,7 @@ const (
 	FlagChangesVersion     = "changes-version"
 	FlagChangesDescription = "changes-description"
 	FlagChangesCommitSha   = "changes-commitsha"
+	FlagBase64             = "base64"
 	defaultTimeoutMillis   = 5000
 )
 
@@ -117,6 +118,10 @@ func GetChangesDescriptionFlag() components.StringFlag {
 
 func GetChangesCommitShaFlag() components.StringFlag {
 	return components.NewStringFlag(FlagChangesCommitSha, "Commit identifier or your change in your VCS.", components.WithStrDefaultValue(""))
+}
+
+func GetBase64Flag() components.BoolFlag {
+	return components.NewBoolFlag(FlagBase64, "Encode the worker source code in base64 before sending.", components.WithBoolDefaultValue(false))
 }
 
 func GetServerDetails(c *components.Context) (*config.ServerDetails, error) {


### PR DESCRIPTION
- [ ] The pull request is targeting the `main` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-platform-services/actions/workflows/tests.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All integration tests have passed locally as they cannot be automated yet.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----