### PR TITLE
Add AI help coverage check to static analysis

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -22,3 +22,6 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
+
+      - name: Check AI help coverage
+        uses: jfrog/.github/actions/ai-help-coverage@main


### PR DESCRIPTION
Adds the AI-help-coverage check to the Static Analysis workflow. It fails CI when a visible command ships without AI-oriented help, so agents never fall back to the short human description.

The action auto-detects this repo's command entry point and checks only its commands. This repo is fully covered, so no commands are skipped.